### PR TITLE
Make it easier to find this module on the Forge

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,7 @@
   "source": "https://github.com/cyberious/puppet-apm",
   "project_page": "https://github.com/cyberious/puppet-apm",
   "issues_url": "https://github.com/cyberious/puppet-apm/issues",
+  "tags": ["atom", "apm"],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",


### PR DESCRIPTION
This commit adds tags to the metadata.json file. The goal of that being
improved findability on the Forge.

Prior to this, if a user searched for 'atom' on the Forge, this module
would not be listed. After this commit, this module will be included in
the list of modules when searching for 'atom'.
